### PR TITLE
meleu's 1st revision

### DIFF
--- a/es-fun-facts-splashscreens.sh
+++ b/es-fun-facts-splashscreens.sh
@@ -6,9 +6,11 @@ home="$(eval echo ~$user)"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 readonly FUN_FACTS_TXT="$SCRIPT_DIR/fun_facts.txt"
+readonly DEFAULT_SPLASH="$SCRIPT_DIR/splash4-3.png"
+readonly ES_DIR="/etc/emulationstation"
 
-ES_DIR="/etc/emulationstation"
-DEFAULT_FONT="$ES_DIR/themes/carbon/art/Cabin-Bold.ttf"
+# TODO: DEFAUL_FONT shouldn't be hardcoded this way. What if theme maintainer change this font in the future?
+readonly DEFAULT_FONT="$ES_DIR/themes/carbon/art/Cabin-Bold.ttf"
 
 function check_dependencies() {
     if ! which convert > /dev/null; then
@@ -23,8 +25,6 @@ function check_dependencies() {
     fi
 }
 
-check_dependencies
-
 function get_current_theme() {
     grep "name=\"ThemeSet\"" "$home/.emulationstation/es_settings.cfg" | sed -n -e "s/^.*value=['\"]\(.*\)['\"].*/\1/p"
 }
@@ -33,21 +33,27 @@ function get_theme_font() {
     xmlstarlet sel -t -v "/theme/view[contains(@name,'detailed')]/textlist/fontPath" "$ES_DIR/themes/$current_theme/$current_theme.xml" 2> /dev/null
 }
 
+# TODO: the logic here can be improved. ;)
 function create_fun_fact() {
-    current_theme=$(get_current_theme)
-    theme_font=$(get_theme_font)
-    
+    current_theme="$(get_current_theme)"
+    local theme_font="$(get_theme_font)"
+    local splash="$1"
+
+    if [[ -f "$splash" ]]; then
+        splash="$DEFAULT_SPLASH"
+    fi
+
     if [[ -z "$theme_font" ]]; then
         font="$DEFAULT_FONT"
     else
-        font="$ES_DIR/themes/$current_theme/art/$(basename $theme_font)"
+        font="$ES_DIR/themes/$current_theme/art/$(basename "$theme_font")"
     fi
-    
-    random_fact="$(shuf -n 1 $FUN_FACTS_TXT)"
-    
+
+    random_fact="$(shuf -n 1 "$FUN_FACTS_TXT")"
+
     echo -e "Creating Fun Fact!\u2122 splashscreen ..."
-    
-    convert splash4-3.png \
+
+    convert "$splash" \
         -size 1000x100 \
         -background none \
         -fill white \
@@ -58,10 +64,12 @@ function create_fun_fact() {
         -geometry +0+25 \
         -composite \
         result.png
-        
+
     echo -e "Fun Fact!\u2122 splashscreen successfully created!"
 }
 
-create_fun_fact
-    
+check_dependencies
+
+create_fun_fact "$1"
+
 feh --full-screen result.png


### PR DESCRIPTION
**I didn't test this code!!** So, please test it before merging.

I'm away from my retropie currently, then unable to test this code. But made some changes, such as:

- defined a `DEFAULT_SPLASH`.
- setting `ES_DIR` and `DEFAULT_FONT` as readonly.
  - TODO: `DEFAUL_FONT` shouldn't be hardcoded. What if theme maintainer change this font in the future?
- TODO: improve `create_fun_fact()` and `get_theme_font()` logic.
- moved `check_dependencies` function call to the bottom.
- added a bunch of `"` around variables/subshells to avoid possible problems with filenames with spaces.
- added a way to let the user specify the splash to be used as template via command line `./script path/to/splash.png`. The default is the pixel splash present in this repo.