### PR TITLE
2nd revision

### DIFF
--- a/es-fun-facts-splashscreens.sh
+++ b/es-fun-facts-splashscreens.sh
@@ -34,15 +34,17 @@ function get_font() {
         "/theme/view[contains(@name,'detailed')]/textlist/fontPath" \
         "$ES_THEMES_DIR/$theme/$theme.xml" 2> /dev/null)"
 
-    [[ -z "$font" ]] && font="$(find "$ES_THEMES_DIR/$theme/" -type f -name '*.ttf' -print -quit)"
-
-    if [[ -z "$font" ]]; then
-        echo "ERROR: Unable to get the font from the \"$theme\" theme files." >&2
-        echo "Aborting..." >&2
-        exit 1
+    if [[ -n "$font" ]]; then
+        font="$ES_THEMES_DIR/$theme/$font"
+    else
+        # note: the find below returns the full path file name
+        font="$(find "$ES_THEMES_DIR/$theme/" -type f -name '*.ttf' -print -quit)"
+        if [[ -z "$font" ]]; then
+            echo "ERROR: Unable to get the font from the \"$theme\" theme files." >&2
+            echo "Aborting..." >&2
+            exit 1
+        fi
     fi
-
-    font="$ES_THEMES_DIR/$theme/$font"
 
     echo "$font"
 }


### PR DESCRIPTION
Again: **THIS CODE WASN'T TESTED!** Test it before merging.

- renamed `ES_DIR` to `ES_THEMES_DIR` and added a trailing `/themes` to its content.

- renamed `get_theme_font()` to `get_font()`.

- moved all logic to get the font to `get_font()`. Included your suggestion to `find` ttf files. ;-)

- removed `DEFAULT_FONT`. The same goal is achieved by getting the font of carbon theme.

- tweaked the `get_current_theme()` to be a sed oneliner. By the way, I was wrong [on my comment about your RegEx](https://retropie.org.uk/forum/post/117357). You need to match `^.*` to achieve your goal. Then your regex is perfect. ;)